### PR TITLE
Revert "chore(deps): update dependency @types/react-dom to v18.0.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@graphql-codegen/typescript-operations": "2.3.5",
     "@graphql-codegen/typescript-react-apollo": "3.2.11",
     "@types/react": "17.0.41",
-    "@types/react-dom": "18.0.1",
+    "@types/react-dom": "18.0.0",
     "@types/zen-observable": "0.8.3",
     "@typescript-eslint/parser": "5.19.0",
     "apollo-server-core": "3.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,12 +2525,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:18.0.1":
-  version: 18.0.1
-  resolution: "@types/react-dom@npm:18.0.1"
+"@types/react-dom@npm:18.0.0":
+  version: 18.0.0
+  resolution: "@types/react-dom@npm:18.0.0"
   dependencies:
     "@types/react": "*"
-  checksum: 6c183e2e50240b77ed767cd968fe061ef4f2b47f84da5ec9e412a767d68c9a004d1f6ccca4295a5aa2c3ee723377e59006a2031f3767c00d8ac9e240a51bb142
+  checksum: 0d8c9cb3e72aefe0dd2b58a49845a200369f01ae92f3f11f642e04efc95dfd1c9380b6592d4273dd6113fb8707947d15b66d56c75c41f39f28bd897f0c08dfa9
   languageName: node
   linkType: hard
 
@@ -3989,7 +3989,7 @@ __metadata:
     "@opentelemetry/node": 0.24.0
     "@prisma/client": 3.12.0
     "@types/react": 17.0.41
-    "@types/react-dom": 18.0.1
+    "@types/react-dom": 18.0.0
     "@types/zen-observable": 0.8.3
     "@typescript-eslint/parser": 5.19.0
     apollo-server-core: 3.6.7


### PR DESCRIPTION
Reverts lowsky/Hands-on-Application-Building-with-GraphQL-and-React#1419
react-dom@18 does not match the other react*- versions