### PR TITLE
switch from postgreql(heroku) to planetscale

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "trigger-e2e-smoke": "sh trigger-circleci-smoke.sh",
     "smoketest": "cd smoketest; yarn --immutable ; yarn cy open -C cypress-local.json",
     "build": "yarn run metainfo && yarn run prisma:generate && next build",
-    "prisma:generate": "prisma generate --data-proxy",
+    "prisma:generate": "prisma generate",
     "prisma:migrate": "DATABASE_URL=\"$MIGRATE_DATABASE_URL\" prisma migrate deploy",
     "metainfo": "sh storeMetaInfo.sh",
     "vercel-build": "COMMIT_REF=$VERCEL_GITHUB_COMMIT_SHA yarn run build ; yarn lint; yarn trigger-e2e-smoke",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,11 +1,17 @@
 generator client {
   provider = "prisma-client-js"
   binaryTargets = ["native", "rhel-openssl-1.0.x"]
+  previewFeatures = ["referentialIntegrity"]
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("PROXIED_DATABASE_URL")
+  provider = "mysql"
+
+  // OLD, with postgres -  url      = env("PROXIED_DATABASE_URL")
+  url = env("DATABASE_URL")
+
+  // used for planetscale:
+  referentialIntegrity = "prisma"
 }
 
 model Card {


### PR DESCRIPTION
MIgrate to planetscale,

* does not need `prisma generate --data-proxy`
* using only one db branch (main)
* env gets injected via integration into vercel: DATABASE_URL