### PR TITLE
remove workaround for netlify, adding @prisma/client as 'externals' in nextjs' webpack - config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,18 +1,10 @@
-module.exports = {
-  webpack: (config, { isServer }) => {
-    config.module.rules.push({
-      test: /\.(graphql|gql)$/,
-      exclude: /node_modules/,
-      loader: 'graphql-tag/loader',
-    });
+// @ts-check
 
-    return config;
-  },
-
+/**
+ * @type {import('next').NextConfig}
+ **/
+const nextConfig = {
   reactStrictMode: true,
-
-  // "For faster deploy times, build IDs should be set to a static value..."
-  generateBuildId: () => 'build',
 
   eslint: {
     // Warning: This allows production builds to successfully complete even if
@@ -20,3 +12,5 @@ module.exports = {
     ignoreDuringBuilds: true,
   },
 };
+
+module.exports = nextConfig;


### PR DESCRIPTION
Netlify's mechanism for functions using zip-it, did not find the binary for
`@prisma/client`
see:
"Query engine binary could not be found on netlify deployment with Next"
https://github.com/prisma/prisma/issues/6051#issuecomment-831136748

Should not be needed for running on vercel, - let's see.