### PR TITLE
fix cleanup-neon-preview.yml GH action

### DIFF
--- a/.github/workflows/cleanup-neon-preview.yml
+++ b/.github/workflows/cleanup-neon-preview.yml
@@ -2,28 +2,18 @@ name: Clean up Preview Deployment
 on:
   pull_request:
     types: [closed]
-#    branches:
-#      - fix-cleanup-neon-gh-action
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }} # Required for commenting on pull requests for private repos
-  NEON_API_KEY: ${{ secrets.NEON_API_KEY }} # You can generate a an API key in your account settings
+  NEON_API_KEY: ${{ secrets.NEON_API_KEY }} # You can generate an API key in your account settings
 
 jobs:
   delete-neon-branch:
     runs-on: ubuntu-latest
     steps:
-      - name: Git branch name-pre
-        run: echo "Branch name ${GIT_BRANCH_NAME}"
-      - name: Git branch name
-        id: git-branch-name
-        uses: EthanSK/git-branch-name-action@v1
-      - name: Echo the branch name
-        run: echo "Branch name ${GIT_BRANCH_NAME}"
-
       - name: Delete Neon Branch
         uses: neondatabase/delete-branch-action@v3.1.4
         with:
           project_id: still-silence-95380932
-          branch: preview/${{ github.head_ref }} # or ? -${{ github.event.pull_request.head.ref }}
+          branch: preview/${{ github.head_ref }}
           api_key: ${{ secrets.NEON_API_KEY }}


### PR DESCRIPTION
uses a new secret
NEON_API_KEY - see https://github.com/lowsky/coolboard/settings/secrets/actions
and 
https://github.com/neondatabase/delete-branch-by-name-action GH action 
to delete the preview of given current branch, something like:
preview/$BRANCH_NAME

see also
https://github.com/neondatabase/delete-branch-by-name-action

or guideline here:
https://github.com/neondatabase/guide-neon-prisma
